### PR TITLE
Fix Missing Icons on Ubuntu

### DIFF
--- a/src/index.theme
+++ b/src/index.theme
@@ -1,7 +1,7 @@
 [Icon Theme]
 Name=Mignon pastel
 Comment=Flat pastel color theme
-Inherits=Mint-Y-Blue,hicolor,Adwaita,breeze
+Inherits=Mint-Y-Blue,hicolor,Adwaita,breeze,Yaru
 Example=folder
 
 # KDE/Plasma Stuff


### PR DESCRIPTION
specifically affects "Ubuntu-Desktop" under settings.
Easily fixed by inheriting from Yaru.